### PR TITLE
Add support for antigen, antibody

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This [zsh](http://www.zsh.org/) plugin adds autocompletion options for all [Clou
 ## Installation
 
 * Download the latest version of the [Cloud Foundry CLI](https://github.com/cloudfoundry/cli#downloads)
+* Follow the instructions for your plugin framework of choice:
+
+### Oh-My-Zsh
 
 * Clone this repo to your zsh plugins directory:
 
@@ -21,6 +24,12 @@ $ git clone https://github.com/frodenas/cf-zsh-autocomplete-plugin.git cf
 
 ```
 plugins=(... cf)
+```
+
+### Antigen, Antigen-hs, Antibody
+
+```
+antigen bundle frodenas/cf-zsh-autocomplete-plugin
 ```
 
 ## Contributing

--- a/cf-zsh-autocomplete-plugin.plugin.zsh
+++ b/cf-zsh-autocomplete-plugin.plugin.zsh
@@ -1,0 +1,1 @@
+fpath+="$(dirname $0)"


### PR DESCRIPTION
[Antigen](https://zsh-users.github.io/antigen/) and [Antibody](https://github.com/getantibody/antibody#readme) support automatic download and sourcing of plugins
hosted on GitHub. This addition allows these Zsh plugin frameworks to work with
this plugin and fixes #2.
