### PR TITLE
Add support for cf-targets plugin

### DIFF
--- a/_cf
+++ b/_cf
@@ -139,6 +139,15 @@ __cf_plugins() {
         _describe 'PLUGIN' cont_cmd
 }
 
+# Output a selectable list of targets (requires cf-targets plugin)
+__cf_targets() {
+    declare -a cont_cmd
+    cont_cmd=($(cf targets | awk '{print $1}'))
+    if [[  'X$cont_cmd' != 'X' ]]
+        _describe 'TARGET' cont_cmd
+}
+
+
 # --------------------------
 # ----- end Helper functions
 # --------------------------
@@ -668,6 +677,23 @@ __uninstall-plugin() {
     '1:plugin name:__cf_plugins'
 }
 
+__save-target() {
+  _arguments \
+    '1:target-name:' \
+    '-f[Force save even if current target is already saved under another name]'
+}
+
+__set-target() {
+  _arguments \
+    '1:target-name:__cf_targets' \
+    '-f[Force target change even if current target is unsaved]'
+}
+
+__delete-target() {
+  _arguments \
+    '1:target-name:__cf_targets'
+}
+
 # ------------------
 # ----- end Commands
 # ------------------
@@ -765,6 +791,10 @@ _1st_arguments=(
   "plugins":"list all available plugin commands"
   "install-plugin":"Install the plugin defined in command argument"
   "uninstall-plugin":"Uninstall the plugin defined in command argument"
+  "targets":"List all saved targets (requires cf-targets plugin)"
+  "save-target":"Save the current target under a given name (requires cf-targets plugin)"
+  "set-target":"Restore a previously saved target (requires cf-targets plugin)"
+  "delete-target":"Delete a saved target (requires cf-targets plugin)" 
 )
 
 # -----------------------
@@ -954,4 +984,10 @@ case "$words[1]" in
     __install-plugin ;;
   uninstall-plugin)
     __uninstall-plugin ;;
+  save-target)
+    __save-target ;;
+  set-target)
+    __set-target ;;
+  delete-target)
+    __delete-target ;;
 esac


### PR DESCRIPTION
I've added support for the super-useful [cf targets plugin](https://github.com/guidowb/cf-targets-plugin). However, as yet it doesn't check that the plugin is actually installed. I've never hacked on zsh before, so not sure of the best way to handle this. Any advice? (If not, I'll try and work it out myself.)